### PR TITLE
feat: migrate template render engine from ejs to liquidjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 <p align='center'>English | <a href="./README.zh.md">中文文档</a></p>
 <br />
-<p align='center'>A file directory-based automated multi-page Vite plugin that supports HTML templates using EJS.</p>
-<p align='center'>基于文件目录的Vite自动化多页面构建插件，支持使用 EJS 的 HTML 模板。</p>
+<p align='center'>A file directory-based automated multi-page Vite plugin that supports HTML templates using LiquidJS.</p>
+<p align='center'>基于文件目录的Vite自动化多页面构建插件，支持使用 LiquidJS 的 HTML 模板。</p>
 <br />
 
 ## Quick Start
@@ -32,7 +32,7 @@ export default defineConfig({
     entryName: "main.tsx",
     sharedData: {},
     enableDevDirectory: true, // enable directory page will render an directory page at "http://localhost:5173/", if you have an index, it will not be affect.
-    ejsOption: {}
+    renderEngineOption: {}
   })],
 })
 ```
@@ -115,16 +115,16 @@ Finished, everything is ready, run `npm run build` to see what is built with `vi
    */
   enableDevDirectory?: boolean
   /**
-   * Top-level data, which will be shared to every entry during EJS render.
+   * Top-level data, which will be shared to every entry during LiquidJS render.
    * @default {}
    */
   sharedData?: object
   /**
-   * EJS render options
-   * @see {@link https://github.com/mde/ejs#options}
+   * Render engine options, currently using LiquidJS
+   * @see {@link https://liquidjs.com/tutorials/options.html}
    * @default {}
    */
-  ejsOption?: object
+  renderEngineOption?: object
   /**
    * Entries of your multi-entry application, for example, `main.js` for Vue, and `main.jsx` for React.
    * @default "main.js"
@@ -162,7 +162,7 @@ Finished, everything is ready, run `npm run build` to see what is built with `vi
    */
   template: string
   /**
-   * EJS render data in this entry, which will be assigned with global `sharedData`
+   * LiquidJS render data in this entry, which will be assigned with global `sharedData`
    * @default {}
    */
   data?: object
@@ -183,7 +183,7 @@ export default pageConfigGenerator({
 
 ### Conditional page configuration
 
-We have an option called `sharedData` cross pages, so you can inject the variables you need, then read them in page's config (or directly use in ejs templates), like this,
+We have an option called `sharedData` cross pages, so you can inject the variables you need, then read them in page's config (or directly use in LiquidJS templates), like this,
 
 ```javascript
 import { pageConfigGenerator } from 'vite-plugin-auto-mpa-html'

--- a/README.zh.md
+++ b/README.zh.md
@@ -9,7 +9,7 @@
 
 <p align='center'><a href="./README.md">English</a> | 中文文档</p>
 <br />
-<p align='center'>基于文件目录的Vite自动化多页面构建插件，支持使用 EJS 的 HTML 模板。</p>
+<p align='center'>基于文件目录的Vite自动化多页面构建插件，支持使用 LiquidJS 的 HTML 模板。</p>
 <br />
 
 ## 快速使用
@@ -31,7 +31,7 @@ export default defineConfig({
     entryName: "main.tsx",
     sharedData: {},
     enableDevDirectory: true, // 在dev环境下临时渲染一个目录页面
-    ejsOption: {}
+    renderEngineOption: {}
   })],
 })
 ```
@@ -114,16 +114,16 @@ export default defineConfig({
    */
   enableDevDirectory?: boolean
   /**
-   * 顶层配置的共享数据，在渲染ejs时会添加到每个入口处。
+   * 顶层配置的共享数据，在渲染LiquidJS时会添加到每个入口处。
    * @default {}
    */
   sharedData?: object
   /**
-   * EJS的一些配置选项
-   * @see {@link https://github.com/mde/ejs#options}
+   * LiquidJS的一些配置选项
+   * @see {@link https://liquidjs.com/tutorials/options.html}
    * @default {}
    */
-  ejsOption?: object
+  renderEngineOption?: object
   /**
    * 多页项目的每个入口文件名, 例如, Vue项目一般为`main.js`, React项目一般为`main.jsx`.
    * @default "main.js"
@@ -163,7 +163,7 @@ export default defineConfig({
    */
   template: string
   /**
-   * 本页EJS模板使用的渲染数据，会与顶层配置的sharedData进行合并
+   * 本页LiquidJS模板使用的渲染数据，会与顶层配置的sharedData进行合并
    * @default {}
    */
   data?: object
@@ -184,7 +184,7 @@ export default pageConfigGenerator({
 
 ### 条件页面配置
 
-借助跨页面的选项 `sharedData` ，您可以注入所需的变量，然后在页面配置中读取它们（或直接在 ejs 模板中使用），例如：
+借助跨页面的选项 `sharedData` ，您可以注入所需的变量，然后在页面配置中读取它们（或直接在 LiquidJS 模板中使用），例如：
 
 ```javascript
 import { pageConfigGenerator } from 'vite-plugin-auto-mpa-html'

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,14 +9,13 @@
       "version": "1.1.3",
       "license": "MIT",
       "dependencies": {
-        "ejs": "^3.1.8",
-        "glob": "^9.3.1"
+        "glob": "^9.3.1",
+        "liquidjs": "^10.16.5"
       },
       "devDependencies": {
         "@commitlint/cli": "^17.6.1",
         "@commitlint/config-conventional": "^17.6.1",
         "@types/connect": "^3.4.35",
-        "@types/ejs": "^3.1.2",
         "@types/node": "^18.15.12",
         "@types/supertest": "^2.0.12",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
@@ -1465,12 +1464,6 @@
       "integrity": "sha512-t73xJJrvdTjXrn4jLS9VSGRbz0nUY3cl2DMGDU48lKl+HR9dbbjW2A9r3g40VA++mQpy6uuHg33gy7du2BKpog==",
       "dev": true
     },
-    "node_modules/@types/ejs": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/@types/ejs/-/ejs-3.1.2.tgz",
-      "integrity": "sha512-ZmiaE3wglXVWBM9fyVC17aGPkLo/UgaOjEiI2FXQfyczrCefORPxIe+2dVmnmk3zkVIbizjrlQzmPGhSYGXG5g==",
-      "dev": true
-    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
@@ -1908,6 +1901,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
       "dependencies": {
         "color-convert": "^2.0.1"
       },
@@ -1988,11 +1982,6 @@
         "node": "*"
       }
     },
-    "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2023,6 +2012,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -2241,6 +2231,7 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2318,6 +2309,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
       "dependencies": {
         "color-name": "~1.1.4"
       },
@@ -2328,7 +2320,8 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
     },
     "node_modules/combined-stream": {
       "version": "1.0.8",
@@ -2370,7 +2363,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/concordance": {
       "version": "5.0.4",
@@ -2632,10 +2626,11 @@
       }
     },
     "node_modules/conventional-changelog-writer/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -2927,20 +2922,6 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
-    },
-    "node_modules/ejs": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
-      "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
-      "dependencies": {
-        "jake": "^10.8.5"
-      },
-      "bin": {
-        "ejs": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.451",
@@ -3370,33 +3351,6 @@
         "node": "^10.12.0 || >=12.0.0"
       }
     },
-    "node_modules/filelist": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/filelist/-/filelist-1.0.4.tgz",
-      "integrity": "sha512-w1cEuf3S+DrLCQL7ET6kz+gmlJdbq9J7yXCSjK/OZCPA+qEN1WyF4ZAf0YYJa4/shHJra2t/d/r8SV4Ji+x+8Q==",
-      "dependencies": {
-        "minimatch": "^5.0.1"
-      }
-    },
-    "node_modules/filelist/node_modules/brace-expansion": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
-      "dependencies": {
-        "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.6",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
-      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -3577,10 +3531,11 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "*"
       }
@@ -3748,10 +3703,11 @@
       }
     },
     "node_modules/git-semver-tags/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -3915,6 +3871,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -4254,23 +4211,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jake": {
-      "version": "10.8.7",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
-      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
-      "dependencies": {
-        "async": "^3.2.3",
-        "chalk": "^4.0.2",
-        "filelist": "^1.0.4",
-        "minimatch": "^3.1.2"
-      },
-      "bin": {
-        "jake": "bin/cli.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/joycon": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
@@ -4440,6 +4380,35 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/liquidjs": {
+      "version": "10.16.5",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.16.5.tgz",
+      "integrity": "sha512-vg/B5/QdqdlCL8r4MztWvt8/rK8hrW+H/sDKxg0VYTWRV6kRqU1lSA2oj2kRwDBqerjuG1wm4jx+xgynmYffKw==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
+      "bin": {
+        "liquid": "bin/liquid.js",
+        "liquidjs": "bin/liquid.js"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/liquidjs"
+      }
+    },
+    "node_modules/liquidjs/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/load-json-file": {
       "version": "4.0.0",
@@ -4650,10 +4619,11 @@
       }
     },
     "node_modules/make-dir/node_modules/semver": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -4834,10 +4804,11 @@
       }
     },
     "node_modules/meow/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -4867,12 +4838,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "braces": "^3.0.2",
+        "braces": "^3.0.3",
         "picomatch": "^2.3.1"
       },
       "engines": {
@@ -4934,6 +4906,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -5722,10 +5695,11 @@
       }
     },
     "node_modules/read-pkg/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
       "dev": true,
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver"
       }
@@ -6288,6 +6262,7 @@
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
       "dependencies": {
         "has-flag": "^4.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -34,14 +34,13 @@
   },
   "license": "MIT",
   "dependencies": {
-    "ejs": "^3.1.8",
-    "glob": "^9.3.1"
+    "glob": "^9.3.1",
+    "liquidjs": "^10.16.5"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.6.1",
     "@commitlint/config-conventional": "^17.6.1",
     "@types/connect": "^3.4.35",
-    "@types/ejs": "^3.1.2",
     "@types/node": "^18.15.12",
     "@types/supertest": "^2.0.12",
     "@typescript-eslint/eslint-plugin": "^5.59.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vite-plugin-auto-mpa-html",
   "version": "1.1.3",
-  "description": "A file directory-based automated multi-page Vite plugin that supports HTML templates using EJS.",
+  "description": "A file directory-based automated multi-page Vite plugin that supports HTML templates using LiquidJS.",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/src/core.ts
+++ b/src/core.ts
@@ -15,7 +15,7 @@ type EntryPathOption = {
     templateName: string;
     entryName: string;
     sharedData?: object
-    ejsOption?: object;
+    renderEngineOption?: object;
 }
 
 export default class Entries {
@@ -50,7 +50,7 @@ export default class Entries {
                     templateName: this.templateName,
                     entryName: this.entryName,
                     sharedData: pluginOption.sharedData,
-                    ejsOption: pluginOption.renderEngineOption,
+                    renderEngineOption: pluginOption.renderEngineOption,
                 }
             }
             this.entries.push(fullDirname)

--- a/src/core.ts
+++ b/src/core.ts
@@ -50,7 +50,7 @@ export default class Entries {
                     templateName: this.templateName,
                     entryName: this.entryName,
                     sharedData: pluginOption.sharedData,
-                    ejsOption: pluginOption.ejsOption,
+                    ejsOption: pluginOption.renderEngineOption,
                 }
             }
             this.entries.push(fullDirname)

--- a/src/template.ts
+++ b/src/template.ts
@@ -71,7 +71,7 @@ export function fetchTemplateHTML(entry: EntryPath, pageConfig: PagePluginConfig
             ...entry.__options.sharedData,
             ...pageConfig.data,
         },
-        entry.__options.ejsOption
+        entry.__options.renderEngineOption
     );
     const generatedHtml = GENERATED_FLAG.concat(htmlContent).replace(
         "</html>",

--- a/src/template.ts
+++ b/src/template.ts
@@ -3,8 +3,9 @@ import {
     readFileSync,
     unlinkSync,
 } from "fs";
-import ejs from "ejs";
-import type { Options as EjsOptions } from "ejs";
+// import ejs from "ejs";
+// import type { Options as EjsOptions } from "ejs";
+import { Liquid, LiquidOptions } from 'liquidjs'
 import { isErrorOfNotFound, PagePluginConfig, ColoringConsole, MergedPluginOption } from "./types";
 import { EntryPath } from "./core";
 import path from "path";
@@ -28,17 +29,26 @@ export const __defaultHTMLTemplate = `<!DOCTYPE html>
   </body>
 </html>`
 
-function renderEjs(
+// function renderEjs(
+//     templateStr: string,
+//     data?: object,
+//     ejsOption?: EjsOptions
+// ): string {
+//     if (data && Object.keys(data).length > 0)
+//         return ejs.render(templateStr, data, {
+//             ...ejsOption,
+//             async: false,
+//         });
+//     return templateStr;
+// }
+
+function renderLiquidTpl(
     templateStr: string,
     data?: object,
-    ejsOption?: EjsOptions
+    liquidjsOption?: LiquidOptions
 ): string {
-    if (data && Object.keys(data).length > 0)
-        return ejs.render(templateStr, data, {
-            ...ejsOption,
-            async: false,
-        });
-    return templateStr;
+    const engine = new Liquid(liquidjsOption);
+    return engine.parseAndRenderSync(templateStr, data);
 }
 
 export function fetchTemplateHTML(entry: EntryPath, pageConfig: PagePluginConfig) {
@@ -55,7 +65,7 @@ export function fetchTemplateHTML(entry: EntryPath, pageConfig: PagePluginConfig
         _console.error(`Page entry "${entry.abs}", its template cannot be found, using default template as fallback! (${e.message})`)
         htmlContent = __defaultHTMLTemplate
     }
-    htmlContent = renderEjs(
+    htmlContent = renderLiquidTpl(
         htmlContent,
         {
             ...entry.__options.sharedData,

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,10 @@
-import type { Options as EjsOption } from "ejs";
+// import type { Options as EjsOption } from "ejs";
+import type { LiquidOptions } from 'liquidjs'
 
 export type PluginOption = {
     entryName?: string;                 // default:main.js
     configName?: string;                // default:config.json
-    ejsOption?: EjsOption;
+    renderEngineOption?: LiquidOptions;
     sharedData?: object;                // will be merged into every page's data
     enableDevDirectory?: boolean;
     experimental?: ExperimentalPluginOption;
@@ -16,8 +17,8 @@ export type ExperimentalPluginOption = {
 
 export type MergedPluginOption = {
     entryName: string;                 // default:main.js
-    configName: string;
-    ejsOption?: EjsOption;
+    configName?: string;
+    renderEngineOption?: LiquidOptions;
     sharedData?: object;                // will be merged into every page's data
     enableDevDirectory: boolean;
     experimental?: ExperimentalPluginOption;


### PR DESCRIPTION
- add `liquidjs`, remove `ejs`.
- change `ejsOption` to `renderEngineOption`